### PR TITLE
Correct length formula for routes crossing the north axis

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -29,9 +29,12 @@ local function connection_length(from_name, to_name)
 	local r2 = to_planet.distance or 0
 	local angle_diff = math.abs(angle2 - angle1)
 
+	if angle_diff > math.pi then
+		angle_diff = 2 * math.pi - angle_diff
+	end
+
 	if r1 > r2 then
 		r1, r2 = r2, r1
-		angle1, angle2 = angle2, angle1
 	end
 
 	local path_length
@@ -41,7 +44,7 @@ local function connection_length(from_name, to_name)
 	elseif math.abs(r2 - r1) < 1e-6 then
 		path_length = r1 * angle_diff
 	else
-		local b = math.abs((angle2 - angle1) / (r2 - r1))
+		local b = math.abs(angle_diff / (r2 - r1))
 
 		if math.abs(b) < 1e-6 then
 			path_length = math.sqrt((r2 - r1) * (r2 - r1) + (r1 * angle_diff) * (r1 * angle_diff))


### PR DESCRIPTION
Previously, Redrawn-Space-Connections saw 0.9 turns and 0.1 turns as 0.8 turns away. This corrects the formula to instead give 0.2 turns.

This is relevant for Igrys, which (after offsetting from Vulcanus) had an angle of around 0.93 turns, making Redrawn-Space-Connections think it was very far away from the other planets, and made a single connection all the way to Maraxsis on the other side of the star.