### PR TITLE
Removed dependency on PlanetsLib: Tiers

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,11 @@
 ---------------------------------------------------------------------------------------------------
 Version: 2.4.1
-Date: ????
+Date: 2026-6-8
   Changes:
+    - Updated route directionality and sorting order to rely on distance from nauvis, instead of PlanetsLib: Tiers.
+    - Removed special case handling for Solar System Edge, since it resulted in some unintended route directionality and sorting.
+  Info:
+    - Removed dependency on PlanetsLib: Tiers, as it was no longer needed.
 ---------------------------------------------------------------------------------------------------
 Version: 2.4.0
 Date: 2025-12-26

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -1,4 +1,5 @@
 local asteroid_util = require("__space-age__.prototypes.planet.asteroid-spawn-definitions")
+local orbits = require("__PlanetsLib__/lib/orbits")
 
 local saved_asteroid_definitions = {}
 
@@ -786,6 +787,26 @@ local function interpolated_asteroid_definitions(a, b)
 	return avg
 end
 
+local function distance_from_nauvis(prototype)
+	-- safety fallback in case planet nauvis doesn't exist
+	local nauvis = data.raw.planet.nauvis
+	local nauvis_distance = nauvis and nauvis.distance or 0
+	local nauvis_orientation = nauvis and nauvis.orientation or 0
+
+	-- thank you PlanetsLib, for this magic function
+	local nauvis_x, nauvis_y = orbits.get_rectangular_position_from_polar(
+		nauvis_distance,
+		nauvis_orientation
+	)
+
+	local prototype_x, prototype_y = orbits.get_rectangular_position_from_polar(
+		prototype.distance or 0,
+		prototype.orientation or 0
+	)
+	-- basic trigonometry for distance between two points
+	return math.sqrt((prototype_x - nauvis_x) ^ 2 + (prototype_y - nauvis_y) ^ 2)
+end
+
 local function get_asteroid_definitions(from, to)
 	if saved_asteroid_definitions[from .. "-" .. to] then
 		return saved_asteroid_definitions[from .. "-" .. to]
@@ -795,21 +816,31 @@ local function get_asteroid_definitions(from, to)
 		return saved_asteroid_definitions[to .. "-" .. from], true
 	end
 
-	if to == "solar-system-edge" then
-		return asteroid_util.spawn_definitions(asteroid_util.aquilo_solar_system_edge), true
-	elseif from == "solar-system-edge" then
-		return asteroid_util.spawn_definitions(asteroid_util.aquilo_solar_system_edge), false
-	end
+	-- with no other mods, this changes Fulgora-SSEdge to SSEdge-Fulgora, seesm unintentional
+	-- so this logic was rewrtitten and moved down to after the should_flip logic
+	--if to == "solar-system-edge" then
+	--	return asteroid_util.spawn_definitions(asteroid_util.aquilo_solar_system_edge), true
+	--elseif from == "solar-system-edge" then
+	--	return asteroid_util.spawn_definitions(asteroid_util.aquilo_solar_system_edge), false
+	--end
 
 	local from_prototype = data.raw.planet[from] or data.raw["space-location"][from]
 	local to_prototype = data.raw.planet[to] or data.raw["space-location"][to]
 
-	local from_tier = data.raw["mod-data"]["PlanetsLib-tierlist"].data[from_prototype.type][from]
-		or data.raw["mod-data"]["PlanetsLib-tierlist"].data.default
-	local to_tier = data.raw["mod-data"]["PlanetsLib-tierlist"].data[to_prototype.type][to]
-		or data.raw["mod-data"]["PlanetsLib-tierlist"].data.default
+	--local from_tier = data.raw["mod-data"]["PlanetsLib-tierlist"].data[from_prototype.type][from]
+	--	or data.raw["mod-data"]["PlanetsLib-tierlist"].data.default
+	--local to_tier = data.raw["mod-data"]["PlanetsLib-tierlist"].data[to_prototype.type][to]
+	--	or data.raw["mod-data"]["PlanetsLib-tierlist"].data.default
+	local from_distance = distance_from_nauvis(from_prototype)
+	local to_distance = distance_from_nauvis(to_prototype)
 
-	local should_flip = from_tier > to_tier
+	--local should_flip = from_tier > to_tier
+	local should_flip = from_distance > to_distance
+
+	-- first decide if should_flip, then use the
+	if from == "solar-system-edge" or to == "solar-system-edge" then
+		return asteroid_util.spawn_definitions(asteroid_util.aquilo_solar_system_edge), should_flip
+	end
 
 	if from_prototype.asteroid_spawn_definitions and to_prototype.asteroid_spawn_definitions then
 		if should_flip then
@@ -896,30 +927,25 @@ end
 
 data:extend(connections_to_add)
 
---== Set order on all space connections based on PlanetsLib tier ==--
+--== Set order on all space connections based on distance from Nauvis ==--
 
-if data.raw["mod-data"]["PlanetsLib-tierlist"] then
-	local tierlist = data.raw["mod-data"]["PlanetsLib-tierlist"].data
+for _, connection in pairs(data.raw["space-connection"] or {}) do
+	local from_prototype = data.raw.planet[connection.from] or data.raw["space-location"][connection.from]
+	local to_prototype = data.raw.planet[connection.to] or data.raw["space-location"][connection.to]
 
-	for _, connection in pairs(data.raw["space-connection"] or {}) do
-		local from_prototype = data.raw.planet[connection.from] or data.raw["space-location"][connection.from]
-		local to_prototype = data.raw.planet[connection.to] or data.raw["space-location"][connection.to]
+	if from_prototype and to_prototype then
+		local from_distance = distance_from_nauvis(from_prototype)
+		local to_distance = distance_from_nauvis(to_prototype)
 
-		if from_prototype and to_prototype then
-			local from_tier = tierlist[from_prototype.type][connection.from] or tierlist.default
-			local to_tier = tierlist[to_prototype.type][connection.to] or tierlist.default
+		local lower_distance = math.min(from_distance, to_distance)
+		local higher_distance = math.max(from_distance, to_distance)
 
-			local lower_tier = math.min(from_tier, to_tier)
-			local higher_tier = math.max(from_tier, to_tier)
-
-			local tier_offset = 1000 -- Accounts for negative tiers
-			connection.order = string.format(
-				"%010.5f-%010.5f-%s",
-				lower_tier + tier_offset,
-				higher_tier + tier_offset,
-				connection.name
-			)
-		end
+		connection.order = string.format(
+			"%010.5f-%010.5f-%s",
+			lower_distance,
+			higher_distance,
+			connection.name
+		)
 	end
 end
 

--- a/info.json
+++ b/info.json
@@ -9,8 +9,7 @@
   "dependencies": [
     "base >= 2.0.0",
     "space-age >= 2.0.0",
-    "PlanetsLib >= 1.7.1",
-    "PlanetsLibTiers"
+    "PlanetsLib >= 1.7.1"
   ],
   "space_travel_required": true
 }


### PR DESCRIPTION
Updated route directionality and order sorting logic from tier-based logic to distance-from-nauvis logic to remove dependency on PlanetsLib: Tiers
Rewrote special case handling for SSEdge, relying on distance from nauvis first to determine if should_flip, still using the Aquilo-SSEdge asteroid spawn definitions as before (fixes Fulgora-SSEdge route becoming SSEdge-Fulgora)
Filled info for version 2.4.1 in changelog